### PR TITLE
interpreter.zig: testsuite call

### DIFF
--- a/src/instruction.zig
+++ b/src/instruction.zig
@@ -40,7 +40,7 @@ pub const InstructionIterator = struct {
                     const tmp_label = try readULEB128Mem(u32, &self.code);
                 }
             },
-            .I32Load, .F32Load, .I32Store, .I64Store, .F64Store => {
+            .CallIndirect, .I32Load, .F32Load, .I32Store, .I64Store, .F64Store => {
                 _ = try readULEB128Mem(u32, &self.code);
                 _ = try readULEB128Mem(u32, &self.code);
             },


### PR DESCRIPTION
- The factorial function wasn't working because I wasn't "consuming" the call's parameter. Now, the label / frame did "consume" the
  parameter but it wasn't cleared off the stack when returning because I when returning from .End, where it is the end of a function, I was just setting the continuation and popping the frame.
- I've added the code to clear the stack of all the operands in the label's / frame's scope
- I'm starting to think I need to do this for a .End that is not the end of a function. At that point I think all of the block ending handling code requires this and therefore we should factor this out