### PR TITLE
refactor: remove value_types from Module

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -51,10 +51,8 @@ pub fn toValueType(comptime t: type) ValueType {
 }
 
 pub const FuncType = struct {
-    params_offset: usize,
-    params_count: usize,
-    results_offset: usize,
-    results_count: usize,
+    params: []const ValueType,
+    results: []const ValueType,
 };
 
 pub const Function = struct {

--- a/src/function.zig
+++ b/src/function.zig
@@ -7,13 +7,13 @@ pub const Function = union(enum) {
         locals: []const u8,
         locals_count: usize,
         code: []const u8,
-        params: []ValueType,
-        results: []ValueType,
+        params: []const ValueType,
+        results: []const ValueType,
         instance: *Instance,
     },
     host_function: struct {
         func: fn (*Interpreter) anyerror!void,
-        params: []ValueType,
-        results: []ValueType,
+        params: []const ValueType,
+        results: []const ValueType,
     },
 };

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -81,12 +81,12 @@ pub const Instance = struct {
                 const external_function = try self.getFunc(i);
                 switch (external_function) {
                     .function => |ef| {
-                        if (!self.module.signaturesEqual2(ef.params, ef.results, func_type)) {
+                        if (!self.module.signaturesEqual(ef.params, ef.results, func_type)) {
                             return error.ImportedFunctionTypeSignatureDoesNotMatch;
                         }
                     },
                     .host_function => |hef| {
-                        if (!self.module.signaturesEqual2(hef.params, hef.results, func_type)) {
+                        if (!self.module.signaturesEqual(hef.params, hef.results, func_type)) {
                             return error.ImportedFunctionTypeSignatureDoesNotMatch;
                         }
                     },
@@ -96,15 +96,13 @@ pub const Instance = struct {
                 const code = self.module.codes.list.items[i - imported_function_count];
                 const func = self.module.functions.list.items[i];
                 const func_type = self.module.types.list.items[func.typeidx];
-                const params = self.module.value_types.list.items[func_type.params_offset .. func_type.params_offset + func_type.params_count];
-                const results = self.module.value_types.list.items[func_type.results_offset .. func_type.results_offset + func_type.results_count];
                 const handle = try self.store.addFunction(Function{
                     .function = .{
                         .code = code.code,
                         .locals = code.locals,
                         .locals_count = code.locals_count,
-                        .params = params,
-                        .results = results,
+                        .params = func_type.params,
+                        .results = func_type.results,
                         .instance = self,
                     },
                 });

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -88,8 +88,8 @@ pub const Interpreter = struct {
                 var block_returns: usize = if (block_type == -0x40) 0 else 1;
                 if (block_type >= 0) {
                     const func_type = self.inst.module.types.list.items[@intCast(usize, block_type)];
-                    block_params = func_type.params_count;
-                    block_returns = func_type.results_count;
+                    block_params = func_type.params.len;
+                    block_returns = func_type.results.len;
                 }
 
                 const end = try instruction.findEnd(false, code);
@@ -108,8 +108,8 @@ pub const Interpreter = struct {
                 var block_returns: usize = if (block_type == -0x40) 0 else 1;
                 if (block_type >= 0) {
                     const func_type = self.inst.module.types.list.items[@intCast(usize, block_type)];
-                    block_params = func_type.params_count;
-                    block_returns = func_type.results_count;
+                    block_params = func_type.params.len;
+                    block_returns = func_type.results.len;
                 }
 
                 // For loop control flow, the continuation is the loop body (including
@@ -132,8 +132,8 @@ pub const Interpreter = struct {
                 var block_returns: usize = if (block_type == -0x40) 0 else 1;
                 if (block_type >= 0) {
                     const func_type = self.inst.module.types.list.items[@intCast(usize, block_type)];
-                    block_params = func_type.params_count;
-                    block_returns = func_type.results_count;
+                    block_params = func_type.params.len;
+                    block_returns = func_type.results.len;
                 }
 
                 // For if control flow, the continuation for our label
@@ -305,7 +305,7 @@ pub const Interpreter = struct {
                         // Check that signatures match
                         // const func_type = module.types.list.items[function.typeidx];
                         const call_indirect_func_type = module.types.list.items[op_func_type_index];
-                        if (!module.signaturesEqual2(func.params, func.results, call_indirect_func_type)) return error.IndirectCallTypeMismatch;
+                        if (!module.signaturesEqual(func.params, func.results, call_indirect_func_type)) return error.IndirectCallTypeMismatch;
 
                         // Make space for locals (again, params already on stack)
                         var j: usize = 0;
@@ -332,7 +332,7 @@ pub const Interpreter = struct {
                     },
                     .host_function => |host_func| {
                         const call_indirect_func_type = module.types.list.items[op_func_type_index];
-                        if (!module.signaturesEqual2(host_func.params, host_func.results, call_indirect_func_type)) return error.IndirectCallTypeMismatch;
+                        if (!module.signaturesEqual(host_func.params, host_func.results, call_indirect_func_type)) return error.IndirectCallTypeMismatch;
 
                         try host_func.func(self);
                     },


### PR DESCRIPTION
- No need to copy the parameter / results values into a separate
  arraylist, just slice into the module bytes
- Simplifies the code
- Rename `signaturesEqual2` to `signaturesEqual` (and delete old `signaturesEqual`)