### PR TITLE
Rearrange testrunner assert_malformed

### DIFF
--- a/test/src/testrunner.zig
+++ b/test/src/testrunner.zig
@@ -578,40 +578,28 @@ pub fn main() anyerror!void {
                             error.CouldntFindExprEnd => continue,
                             error.ElementsCountMismatch => continue,
                             error.CouldntFindEnd => continue, // test/testsuite/binary.wast:910 bad br_table means we don't find end
-                            else => {
-                                std.debug.print("Expected error for trap {s}, got error: {}\n", .{ trap, err });
-                                return error.TestsuiteExpectedUnexpectedEnd;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "magic header not detected")) {
                         switch (err) {
                             error.MagicNumberNotFound => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "unknown binary version")) {
                         switch (err) {
                             error.UnknownBinaryVersion => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "malformed section id")) {
                         switch (err) {
                             error.UnknownSectionId => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
@@ -621,10 +609,7 @@ pub fn main() anyerror!void {
                             error.ExpectedFuncTypeTag => continue,
                             error.Overflow => continue,
                             error.UnknownSectionId => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
@@ -632,30 +617,21 @@ pub fn main() anyerror!void {
                         switch (err) {
                             error.MalformedCallIndirectReserved => continue,
                             error.MalformedMemoryReserved => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "too many locals")) {
                         switch (err) {
                             error.TooManyLocals => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "function and code section have inconsistent lengths")) {
                         switch (err) {
                             error.FunctionCodeSectionsInconsistent => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
@@ -674,20 +650,14 @@ pub fn main() anyerror!void {
                             error.DatasCountMismatch => continue,
                             error.InvalidValue => continue,
                             error.MalformedSectionMismatchedSize => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "malformed import kind")) {
                         switch (err) {
                             error.InvalidValue => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
@@ -696,45 +666,34 @@ pub fn main() anyerror!void {
                             error.Overflow => continue,
                             error.UnknownSectionId => continue,
                             error.InvalidValue => continue, // test/testsuite/binary.wast:601 I think the test is wrong
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "junk after last section")) {
                         switch (err) {
                             error.MultipleStartSections => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "malformed mutability")) {
                         switch (err) {
                             error.InvalidValue => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
 
                     if (mem.eql(u8, trap, "malformed UTF-8 encoding")) {
                         switch (err) {
                             error.NameNotUTF8 => continue,
-                            else => {
-                                std.debug.print("Unexpected error: {}\n", .{err});
-                                return error.ExpectedError;
-                            },
+                            else => {},
                         }
                     }
-                }
 
-                return error.ExpectedError;
+                    std.debug.print("Trap: {s}, got error error: {}\n", .{err});
+                    return error.ErrorDoesNotMatchTrap;
+                }
             },
             .action => {
                 const action = command.action.action;

--- a/test/src/testrunner.zig
+++ b/test/src/testrunner.zig
@@ -566,195 +566,171 @@ pub fn main() anyerror!void {
                     std.debug.print("ERROR (malformed): {s}:{}\n", .{ r.source_filename, command.assert_malformed.line });
                 }
 
-                if (mem.eql(u8, trap, "unexpected end") or mem.eql(u8, trap, "length out of bounds")) {
-                    if (module.decode()) |_| {
-                        return error.TestsuiteExpectedUnexpectedEnd;
-                    } else |err| switch (err) {
-                        error.Overflow => continue,
-                        error.UnexpectedEndOfInput => continue,
-                        error.FunctionCodeSectionsInconsistent => continue,
-                        error.EndOfStream => continue,
-                        error.CouldntFindExprEnd => continue,
-                        error.ElementsCountMismatch => continue,
-                        error.CouldntFindEnd => continue, // test/testsuite/binary.wast:910 bad br_table means we don't find end
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.TestsuiteExpectedUnexpectedEnd;
-                        },
+                if (module.decode()) |_| {
+                    return error.TestsuiteMalformedExpectedButDecodedOk;
+                } else |err| {
+                    if (mem.eql(u8, trap, "unexpected end") or mem.eql(u8, trap, "length out of bounds")) {
+                        switch (err) {
+                            error.Overflow => continue,
+                            error.UnexpectedEndOfInput => continue,
+                            error.FunctionCodeSectionsInconsistent => continue,
+                            error.EndOfStream => continue,
+                            error.CouldntFindExprEnd => continue,
+                            error.ElementsCountMismatch => continue,
+                            error.CouldntFindEnd => continue, // test/testsuite/binary.wast:910 bad br_table means we don't find end
+                            else => {
+                                std.debug.print("Expected error for trap {}, got error: {}\n", .{ trap, err });
+                                return error.TestsuiteExpectedUnexpectedEnd;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "magic header not detected")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.MagicNumberNotFound => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "magic header not detected")) {
+                        switch (err) {
+                            error.MagicNumberNotFound => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "unknown binary version")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.UnknownBinaryVersion => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "unknown binary version")) {
+                        switch (err) {
+                            error.UnknownBinaryVersion => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "malformed section id")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.UnknownSectionId => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "malformed section id")) {
+                        switch (err) {
+                            error.UnknownSectionId => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "integer representation too long")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.InvalidValue => continue,
-                        error.ExpectedFuncTypeTag => continue,
-                        error.Overflow => continue,
-                        error.UnknownSectionId => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "integer representation too long")) {
+                        switch (err) {
+                            error.InvalidValue => continue,
+                            error.ExpectedFuncTypeTag => continue,
+                            error.Overflow => continue,
+                            error.UnknownSectionId => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "zero flag expected")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.MalformedCallIndirectReserved => continue,
-                        error.MalformedMemoryReserved => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "zero flag expected")) {
+                        switch (err) {
+                            error.MalformedCallIndirectReserved => continue,
+                            error.MalformedMemoryReserved => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "too many locals")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.TooManyLocals => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "too many locals")) {
+                        switch (err) {
+                            error.TooManyLocals => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "function and code section have inconsistent lengths")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.FunctionCodeSectionsInconsistent => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "function and code section have inconsistent lengths")) {
+                        switch (err) {
+                            error.FunctionCodeSectionsInconsistent => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "unexpected end of section or function") or mem.eql(u8, trap, "section size mismatch")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.UnexpectedEndOfInput => continue,
-                        error.UnknownSectionId => continue, // if a section declares more elements than it has we might get this
-                        error.TypeCountMismatch => continue,
-                        error.ImportsCountMismatch => continue,
-                        error.TablesCountMismatch => continue,
-                        error.MemoriesCountMismatch => continue,
-                        error.GlobalsCountMismatch => continue,
-                        error.ElementsCountMismatch => continue,
-                        error.FunctionsCountMismatch => continue,
-                        error.CodesCountMismatch => continue,
-                        error.DatasCountMismatch => continue,
-                        error.InvalidValue => continue,
-                        error.MalformedSectionMismatchedSize => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "unexpected end of section or function") or mem.eql(u8, trap, "section size mismatch")) {
+                        switch (err) {
+                            error.UnexpectedEndOfInput => continue,
+                            error.UnknownSectionId => continue, // if a section declares more elements than it has we might get this
+                            error.TypeCountMismatch => continue,
+                            error.ImportsCountMismatch => continue,
+                            error.TablesCountMismatch => continue,
+                            error.MemoriesCountMismatch => continue,
+                            error.GlobalsCountMismatch => continue,
+                            error.ElementsCountMismatch => continue,
+                            error.FunctionsCountMismatch => continue,
+                            error.CodesCountMismatch => continue,
+                            error.DatasCountMismatch => continue,
+                            error.InvalidValue => continue,
+                            error.MalformedSectionMismatchedSize => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "malformed import kind")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.InvalidValue => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "malformed import kind")) {
+                        switch (err) {
+                            error.InvalidValue => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "integer too large")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.Overflow => continue,
-                        error.UnknownSectionId => continue,
-                        error.InvalidValue => continue, // test/testsuite/binary.wast:601 I think the test is wrong
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "integer too large")) {
+                        switch (err) {
+                            error.Overflow => continue,
+                            error.UnknownSectionId => continue,
+                            error.InvalidValue => continue, // test/testsuite/binary.wast:601 I think the test is wrong
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "junk after last section")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.MultipleStartSections => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "junk after last section")) {
+                        switch (err) {
+                            error.MultipleStartSections => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "malformed mutability")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.InvalidValue => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "malformed mutability")) {
+                        switch (err) {
+                            error.InvalidValue => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
-                }
 
-                if (mem.eql(u8, trap, "malformed UTF-8 encoding")) {
-                    if (module.decode()) |_| {
-                        return error.ExpectedError;
-                    } else |err| switch (err) {
-                        error.NameNotUTF8 => continue,
-                        else => {
-                            std.debug.print("Unexpected error: {}\n", .{err});
-                            return error.ExpectedError;
-                        },
+                    if (mem.eql(u8, trap, "malformed UTF-8 encoding")) {
+                        switch (err) {
+                            error.NameNotUTF8 => continue,
+                            else => {
+                                std.debug.print("Unexpected error: {}\n", .{err});
+                                return error.ExpectedError;
+                            },
+                        }
                     }
                 }
 

--- a/test/src/testrunner.zig
+++ b/test/src/testrunner.zig
@@ -579,7 +579,7 @@ pub fn main() anyerror!void {
                             error.ElementsCountMismatch => continue,
                             error.CouldntFindEnd => continue, // test/testsuite/binary.wast:910 bad br_table means we don't find end
                             else => {
-                                std.debug.print("Expected error for trap {}, got error: {}\n", .{ trap, err });
+                                std.debug.print("Expected error for trap {s}, got error: {}\n", .{ trap, err });
                                 return error.TestsuiteExpectedUnexpectedEnd;
                             },
                         }

--- a/test/src/testrunner.zig
+++ b/test/src/testrunner.zig
@@ -691,7 +691,7 @@ pub fn main() anyerror!void {
                         }
                     }
 
-                    std.debug.print("Trap: {s}, got error error: {}\n", .{err});
+                    std.debug.print("Trap: {s}, got error error: {}\n", .{ trap, err });
                     return error.ErrorDoesNotMatchTrap;
                 }
             },


### PR DESCRIPTION
# Description

- Only do a single `module.decode` and single capture of `err`