### PR TITLE
Dispatch misc instructions in the same way as the other instructions

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -2090,6 +2090,10 @@ pub const VirtualMachine = struct {
         return dispatch(self, ip + 1, code);
     }
 
+    fn misc(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {
+        return miscDispatch(self, ip, code);
+    }
+
     fn @"i32.trunc_sat_f32_s"(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {
         const c1 = self.popOperand(f32);
         const trunc = @trunc(c1);
@@ -2132,10 +2136,6 @@ pub const VirtualMachine = struct {
 
         self.pushOperandNoCheck(u32, @floatToInt(u32, trunc));
         return dispatch(self, ip + 1, code);
-    }
-
-    fn misc(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {
-        return miscDispatch(self, ip, code);
     }
 
     fn @"i32.trunc_sat_f64_s"(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -91,33 +91,6 @@ pub const VirtualMachine = struct {
         return try @call(.{ .modifier = .always_tail }, lookup[@enumToInt(next_instr)], .{ self, next_ip, code });
     }
 
-    const misc_lookup = [18]InstructionFunction{
-        @"i32.trunc_sat_f32_s",
-        @"i32.trunc_sat_f32_u",
-        @"i32.trunc_sat_f64_s",
-        @"i32.trunc_sat_f64_u",
-        @"i64.trunc_sat_f32_s",
-        @"i64.trunc_sat_f32_u",
-        @"i64.trunc_sat_f64_s",
-        @"i64.trunc_sat_f64_u",
-        @"memory.init",
-        @"data.drop",
-        @"memory.copy",
-        @"memory.fill",
-        @"table.init",
-        @"elem.drop",
-        @"table.copy",
-        @"table.grow",
-        @"table.size",
-        @"table.fill",
-    };
-
-    inline fn miscDispatch(self: *VirtualMachine, next_ip: usize, code: []Rr) WasmError!void {
-        const next_instr = code[next_ip].misc;
-
-        return try @call(.{ .modifier = .always_tail }, misc_lookup[@enumToInt(next_instr)], .{ self, next_ip, code });
-    }
-
     pub const REF_NULL: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
     fn impl_ni(_: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {
@@ -2092,6 +2065,17 @@ pub const VirtualMachine = struct {
 
     fn misc(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {
         return miscDispatch(self, ip, code);
+    }
+
+    const misc_lookup = [18]InstructionFunction{
+        @"i32.trunc_sat_f32_s", @"i32.trunc_sat_f32_u", @"i32.trunc_sat_f64_s", @"i32.trunc_sat_f64_u", @"i64.trunc_sat_f32_s", @"i64.trunc_sat_f32_u", @"i64.trunc_sat_f64_s", @"i64.trunc_sat_f64_u", @"memory.init", @"data.drop", @"memory.copy", @"memory.fill", @"table.init", @"elem.drop", @"table.copy", @"table.grow",
+        @"table.size",          @"table.fill",
+    };
+
+    inline fn miscDispatch(self: *VirtualMachine, next_ip: usize, code: []Rr) WasmError!void {
+        const next_instr = code[next_ip].misc;
+
+        return try @call(.{ .modifier = .always_tail }, misc_lookup[@enumToInt(next_instr)], .{ self, next_ip, code });
     }
 
     fn @"i32.trunc_sat_f32_s"(self: *VirtualMachine, ip: usize, code: []Rr) WasmError!void {


### PR DESCRIPTION
# Description

Previously the misc instructions were dispatched in a large switch statement. This moves to the same model as all other instructions, i.e. they are now `always_tail`'d with via a `misc_lookup` table