### PR TITLE
Clean up validation

### DIFF
--- a/src/validator.zig
+++ b/src/validator.zig
@@ -231,10 +231,7 @@ pub const Validator = struct {
             .select_t,
             .@"table.get",
             .@"table.set",
-            => {
-                // These instructions are handled separately
-                unreachable;
-            },
+            => {},
             .@"unreachable" => try v.setUnreachable(),
             .nop => {},
             .end => {

--- a/src/validator.zig
+++ b/src/validator.zig
@@ -136,6 +136,37 @@ pub const Validator = struct {
         }
     }
 
+    pub fn validateEnd(v: *Validator) !void {
+        const frame = try v.popControlFrame();
+        _ = try v.pushOperands(frame.end_types);
+    }
+
+    pub fn validateElse(v: *Validator) !void {
+        const frame = try v.popControlFrame();
+        if (frame.opcode != .@"if") return error.ElseMustOnlyOccurAfterIf;
+        try v.pushControlFrame(.@"else", frame.start_types, frame.end_types);
+    }
+
+    pub fn validateSelect(v: *Validator) !void {
+        _ = try v.popOperandExpecting(ValTypeUnknown{ .Known = .I32 });
+        const t1 = try v.popOperand();
+        const t2 = try v.popOperand();
+
+        if (!(isNum(t1) and isNum(t2))) return error.ExpectingBothNum;
+        if (!valueTypeEqual(t1, t2) and !valueTypeEqual(t1, ValTypeUnknown.Unknown) and !valueTypeEqual(t2, ValTypeUnknown.Unknown)) return error.ValidatorSelect;
+        if (valueTypeEqual(t1, ValTypeUnknown.Unknown)) {
+            try v.pushOperand(t2);
+        } else {
+            try v.pushOperand(t1);
+        }
+    }
+
+    pub fn validateReturn(v: *Validator) !void {
+        const frame = v.ctrl_stack.items[0];
+        try v.popOperands(labelTypes(frame));
+        try v.setUnreachable();
+    }
+
     pub fn validateMisc(v: *Validator, misc_type: MiscOpcode) !void {
         switch (misc_type) {
             .@"i32.trunc_sat_f32_s",
@@ -233,40 +264,14 @@ pub const Validator = struct {
             .@"table.set",
             => {
                 // These instructions are handled separately
-                unreachable;
             },
             .@"unreachable" => try v.setUnreachable(),
             .nop => {},
-            .end => {
-                const frame = try v.popControlFrame();
-                _ = try v.pushOperands(frame.end_types);
-            },
-            .@"else" => {
-                const frame = try v.popControlFrame();
-                if (frame.opcode != .@"if") return error.ElseMustOnlyOccurAfterIf;
-                try v.pushControlFrame(.@"else", frame.start_types, frame.end_types);
-            },
-            .@"return" => {
-                const frame = v.ctrl_stack.items[0];
-                try v.popOperands(labelTypes(frame));
-                try v.setUnreachable();
-            },
-            .drop => {
-                _ = try v.popOperand();
-            },
-            .select => {
-                _ = try v.popOperandExpecting(ValTypeUnknown{ .Known = .I32 });
-                const t1 = try v.popOperand();
-                const t2 = try v.popOperand();
-
-                if (!(isNum(t1) and isNum(t2))) return error.ExpectingBothNum;
-                if (!valueTypeEqual(t1, t2) and !valueTypeEqual(t1, ValTypeUnknown.Unknown) and !valueTypeEqual(t2, ValTypeUnknown.Unknown)) return error.ValidatorSelect;
-                if (valueTypeEqual(t1, ValTypeUnknown.Unknown)) {
-                    try v.pushOperand(t2);
-                } else {
-                    try v.pushOperand(t1);
-                }
-            },
+            .end => try v.validateEnd(),
+            .@"else" => try v.validateElse(),
+            .@"return" => try v.validateReturn(),
+            .drop => _ = try v.popOperand(),
+            .select => try v.validateSelect(),
             .@"memory.size" => {
                 _ = try v.pushOperand(ValTypeUnknown{ .Known = .I32 });
             },


### PR DESCRIPTION
# Description

Remove another place where we need to add opcodes + have the compiler help us more.

Note: I tried to get rid of the `var rr: Rr = undefined` by using `break` from a block, but that doesn't seem to be working (will try again in the future).