### PR TITLE
Fast memory.fill and memory.copy

### DIFF
--- a/src/instance/vm.zig
+++ b/src/instance/vm.zig
@@ -2298,24 +2298,17 @@ pub const VirtualMachine = struct {
 
         if (@as(u33, src) + @as(u33, n) > mem_size) return error.OutOfBoundsMemoryAccess;
         if (@as(u33, dest) + @as(u33, n) > mem_size) return error.OutOfBoundsMemoryAccess;
+
         if (n == 0) {
             return dispatch(self, ip + 1, code);
         }
 
+        // FIXME: move initial bounds check into Memory implementation
+        const data = memory.memory();
         if (dest <= src) {
-            var i: u32 = 0;
-            while (i < n) : (i += 1) {
-                // FIXME: no check
-                // FIXME: take single address which is u33 (for write / read)
-                try memory.write(u8, 0, dest + i, try memory.read(u8, 0, src + i));
-            }
+            memory.uncheckedCopy(dest, data[src..src+n]);
         } else {
-            var i: u32 = 0;
-            while (i < n) : (i += 1) {
-                // FIXME: no check
-                // FIXME: take single address which is u33?
-                try memory.write(u8, 0, dest + n - 1 - i, try memory.read(u8, 0, src + n - 1 - i));
-            }
+            memory.uncheckedCopyBackwards(dest, data[src..src+n]);
         }
 
         return dispatch(self, ip + 1, code);
@@ -2334,12 +2327,7 @@ pub const VirtualMachine = struct {
             return dispatch(self, ip + 1, code);
         }
 
-        var i: u32 = 0;
-        while (i < n) : (i += 1) {
-            // FIXME: no check
-            // FIXME: take single address which is u33 (for write / read)
-            try memory.write(u8, 0, dest + i, @truncate(u8, value));
-        }
+        memory.uncheckedFill(dest, n, @truncate(u8, value));
 
         return dispatch(self, ip + 1, code);
     }

--- a/src/store/memory.zig
+++ b/src/store/memory.zig
@@ -52,6 +52,18 @@ pub const Memory = struct {
         mem.copy(u8, self.data.items[address .. address + data.len], data);
     }
 
+   pub fn uncheckedFill(self: *Memory, dst_address: u32, n: u32, value: u8) void {
+        mem.set(u8, self.data.items[dst_address .. dst_address + n], value);
+    }
+
+    pub fn uncheckedCopy(self: *Memory, dst_address: u32, data: []const u8) void {
+        mem.copy(u8, self.data.items[dst_address .. dst_address + data.len], data);
+    }
+
+    pub fn uncheckedCopyBackwards(self: *Memory, dst_address: u32, data: []const u8) void {
+        mem.copyBackwards(u8, self.data.items[dst_address .. dst_address + data.len], data);
+    }
+
     // as per copy but don't actually mutate
     pub fn check(self: *Memory, address: u32, data: []const u8) !void {
         if (address + data.len > self.data.items.len) return error.OutOfBoundsMemoryAccess;


### PR DESCRIPTION
# Description

The previous implementations of `memory.fill` and `memory.copy` were correct in a semantic sense but not in a performant sense (the reason for their introduction into the WebAssembly spec).

This removes individual byte writes (with a check on each byte written...i.e. slow) with trusting the bounds check in the virtual instruction handler.

## Follow ups

- I think we should just push the bounds check into `Memory`
    - If we do this can we unify `Memory.copy` and `Memory.uncheckedCopy`