### PR TITLE
Add a generate_interface program 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,6 +52,16 @@ jobs:
       - name: Build interface
         working-directory: ./test/interface
         run: zig build
+  build_genertate_interface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+      - name: Build generate interface
+        working-directory: ./test/generate_interface
+        run: zig build
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/test/generate_interface/README.md
+++ b/test/generate_interface/README.md
@@ -1,0 +1,3 @@
+# generate_interface
+
+Provide `generate_interface` with a `.wasm` and it will print out host function stubs and `addHostFunction` code for the interfacing with that `.wasm` binary.

--- a/test/generate_interface/build.zig
+++ b/test/generate_interface/build.zig
@@ -1,0 +1,26 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "generate_interface",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.addAnonymousModule("zware", .{
+        .source_file = .{ .path = "../../src/main.zig" },
+    });
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/test/generate_interface/src/main.zig
+++ b/test/generate_interface/src/main.zig
@@ -30,7 +30,7 @@ pub fn main() !void {
     var bw = std.io.bufferedWriter(stdout_file);
     const stdout = bw.writer();
 
-    try stdout.print("const std = @import(\"std\");\n\n", .{});
+    try stdout.print("const std = @import(\"std\");\n", .{});
     try stdout.print("const zware = @import(\"zware\");\n\n", .{});
 
     // Generate loader

--- a/test/generate_interface/src/main.zig
+++ b/test/generate_interface/src/main.zig
@@ -82,7 +82,7 @@ pub fn main() !void {
         for (function_type.params) |_| {
             try stdout.print("{{}}, ", .{});
         }
-        try stdout.print(")\", .{{", .{});
+        try stdout.print(")\\n\", .{{", .{});
         for (function_type.params, 0..) |_, i| {
             try stdout.print("param{}, ", .{i});
         }

--- a/test/generate_interface/src/main.zig
+++ b/test/generate_interface/src/main.zig
@@ -30,6 +30,7 @@ pub fn main() !void {
     var bw = std.io.bufferedWriter(stdout_file);
     const stdout = bw.writer();
 
+    try stdout.print("const std = @import(\"std\");\n\n", .{});
     try stdout.print("const zware = @import(\"zware\");\n\n", .{});
 
     // Generate loader

--- a/test/generate_interface/src/main.zig
+++ b/test/generate_interface/src/main.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const mem = std.mem;
+const fs = std.fs;
+const fmt = std.fmt;
+const process = std.process;
+const zware = @import("zware");
+const ArrayList = std.ArrayList;
+const Module = zware.Module;
+const Store = zware.Store;
+const Instance = zware.Instance;
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator;
+var gpa = GeneralPurposeAllocator(.{}){};
+
+pub fn main() !void {
+    var args = process.args();
+    _ = args.skip();
+    const filename = args.next() orelse return error.NoFilename;
+
+    defer _ = gpa.deinit();
+    var alloc = gpa.allocator();
+
+    const program = try fs.cwd().readFileAlloc(alloc, filename, 0xFFFFFFF);
+    defer alloc.free(program);
+
+    var module = Module.init(alloc, program);
+    defer module.deinit();
+    try module.decode();
+
+    const stdout_file = std.io.getStdOut().writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout = bw.writer();
+
+    try stdout.print("const zware = @import(\"zware\");\n\n", .{});
+
+    // Generate loader
+    try stdout.print("pub fn initHostFunctions(module: []const u8, store: *zware.Store) !void {{\n", .{});
+    for (module.functions.list.items) |function| {
+        const import_index = function.import orelse continue;
+
+        const function_import = module.imports.list.items[import_index];
+
+        // const function_type = module.types.list.items[function.typeidx];
+
+        try stdout.print("\ttry store.addHostFunction(module, \"{s}\", {s}, [_]ValType{{}}, [_]ValType{{}});\n", .{function_import.name, function_import.name});
+    }
+    try stdout.print("}}\n\n", .{});
+
+    // Generate stubs
+    for (module.functions.list.items) |function| {
+        const import_index = function.import orelse continue;
+
+        const function_import = module.imports.list.items[import_index];
+
+        try stdout.print("pub fn {s}(vm: *VirtualMachine) WasmError!void {{\n", .{function_import.name});
+        try stdout.print("\t@panic(\"Unimplemented: {s}\");\n", .{function_import.name});
+        try stdout.print("}}\n\n", .{});
+    }
+
+    try bw.flush(); // don't forget to flush!
+}

--- a/test/interface/README.md
+++ b/test/interface/README.md
@@ -1,0 +1,3 @@
+# interface
+
+Provide `interface` with a `.wasm` file path and it will print out the imports / exports of the `.wasm` file.


### PR DESCRIPTION
# Description

To help write host functions for known wasm binaries, adds a `generate_interface` binary that given a `.wasm` binary will generate host function stubs and a `initHostFunctions` function.

E.g. if I take the `.wasm` from https://silentspacemarine.com/ the binary generates:

```zig
const std = @import("std");
const zware = @import("zware");

pub fn initHostFunctions(module: []const u8, store: *zware.Store) !void {
	try store.addHostFunction(module, "exit", exit, [_]ValType{.I32, }, [_]ValType{});
	try store.addHostFunction(module, "emscripten_cancel_main_loop", emscripten_cancel_main_loop, [_]ValType{}, [_]ValType{});
	try store.addHostFunction(module, "emscripten_force_exit", emscripten_force_exit, [_]ValType{.I32, }, [_]ValType{});
	try store.addHostFunction(module, "time", time, [_]ValType{.I32, }, [_]ValType{.I32, });
	try store.addHostFunction(module, "__assert_fail", __assert_fail, [_]ValType{.I32, .I32, .I32, .I32, }, [_]ValType{});
	try store.addHostFunction(module, "emscripten_sleep", emscripten_sleep, [_]ValType{.I32, }, [_]ValType{});

        [deletia...]
}

pub fn exit(vm: *VirtualMachine) WasmError!void {
	const param0 = vm.popOperand(i32);
	std.debug.print("Unimplemented: exit({}, )", .{param0, });
	@panic("Unimplemented: exit");
}

pub fn emscripten_cancel_main_loop(vm: *VirtualMachine) WasmError!void {
	std.debug.print("Unimplemented: emscripten_cancel_main_loop()", .{});
	@panic("Unimplemented: emscripten_cancel_main_loop");
}

pub fn emscripten_force_exit(vm: *VirtualMachine) WasmError!void {
	const param0 = vm.popOperand(i32);
	std.debug.print("Unimplemented: emscripten_force_exit({}, )", .{param0, });
	@panic("Unimplemented: emscripten_force_exit");
}

pub fn time(vm: *VirtualMachine) WasmError!void {
	const param0 = vm.popOperand(i32);
	std.debug.print("Unimplemented: time({}, )", .{param0, });
	@panic("Unimplemented: time");
}

pub fn __assert_fail(vm: *VirtualMachine) WasmError!void {
	const param0 = vm.popOperand(i32);
	const param1 = vm.popOperand(i32);
	const param2 = vm.popOperand(i32);
	const param3 = vm.popOperand(i32);
	std.debug.print("Unimplemented: __assert_fail({}, {}, {}, {}, )", .{param0, param1, param2, param3, });
	@panic("Unimplemented: __assert_fail");
}

pub fn emscripten_sleep(vm: *VirtualMachine) WasmError!void {
	const param0 = vm.popOperand(i32);
	std.debug.print("Unimplemented: emscripten_sleep({}, )", .{param0, });
	@panic("Unimplemented: emscripten_sleep");
}

[deletia...]
```

## Follow up

- TODO: just merge with interface