### PR TITLE
zware-gen: Improve interface

### DIFF
--- a/tools/zware-gen/README.md
+++ b/tools/zware-gen/README.md
@@ -1,3 +1,4 @@
-# generate_interface
+# zware-gen
 
-Provide `generate_interface` with a `.wasm` and it will print out host function stubs and `exposeHostFunction` code for the interfacing with that `.wasm` binary.
+Give me a `.wasm` and I will generate zig code for its interface (wrappers to call into the `.wasm` module and stubs for host functions). Implement
+the host functions correctly and your `.wasm` module will run


### PR DESCRIPTION
# Description

Wrap the calls to `.wasm` module functions in a struct that carries its instance

E.g. for `fib.wasm` we get:

```zig
pub const Api = struct {
        instance: *zware.Instance,

        const Self = @This();

        pub fn init(instance: *zware.Instance) Self {
                return .{ .instance = instance };
        }

        pub fn fib(self: *Self, param0: i32) !i32 {
                var in = [_]u64{@bitCast(@as(i64, param0))};
                var out = [_]u64{0};
                try self.instance.invoke("fib", in[0..], out[0..], .{});
                return @bitCast(@as(u32, @truncate(out[0])));
        }
};
```