### PR TITLE
separate module decoding state/methods into their own struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-cache
+.zig-cache
 zig-out
 test/testrunner/bin

--- a/src/module/parser.zig
+++ b/src/module/parser.zig
@@ -3,6 +3,7 @@ const math = std.math;
 const leb = std.leb;
 const ArrayList = std.ArrayList;
 const Module = @import("../module.zig").Module;
+const Decoder = @import("../module.zig").Decoder;
 const LocalType = @import("../module.zig").LocalType;
 const Opcode = @import("../opcode.zig").Opcode;
 const MiscOpcode = @import("../opcode.zig").MiscOpcode;
@@ -24,6 +25,7 @@ pub const Parser = struct {
     code: []const u8 = undefined,
     code_ptr: usize,
     module: *Module,
+    decoder: *Decoder,
     validator: Validator = undefined,
     params: ?[]const ValType,
     locals: ?[]LocalType,
@@ -32,10 +34,11 @@ pub const Parser = struct {
     is_constant: bool = false,
     scope: usize,
 
-    pub fn init(module: *Module) Parser {
+    pub fn init(module: *Module, decoder: *Decoder) Parser {
         return Parser{
             .code_ptr = module.parsed_code.items.len,
             .module = module,
+            .decoder = decoder,
             .params = null,
             .locals = null,
             .continuation_stack_ptr = 0,
@@ -62,7 +65,7 @@ pub const Parser = struct {
         }
 
         const bytes_read = self.bytesRead();
-        _ = try self.module.readSlice(bytes_read);
+        _ = try self.decoder.readSlice(bytes_read);
 
         // Patch last end so that it is return
         self.module.parsed_code.items[self.module.parsed_code.items.len - 1] = .@"return";
@@ -104,7 +107,7 @@ pub const Parser = struct {
         }
 
         const bytes_read = self.bytesRead();
-        _ = try self.module.readSlice(bytes_read);
+        _ = try self.decoder.readSlice(bytes_read);
 
         // Patch last end so that it is return
         self.module.parsed_code.items[self.module.parsed_code.items.len - 1] = .@"return";


### PR DESCRIPTION
This change moves the state (fixed buffer stream) and methods (decode/read) around decoding a module into a separate struct `Decoder` so they can be discarded after the module is decoded.

Along with this change, I also fixed a few more things I noticed along the way:

* removed version field from Module (unused)
* combined common code between min/max limit cases
* rename `module` field to `wasm_bin` on Module struct to distinguish the wasm binary buffer from the higher level module object
* fixed `readSlice` so it doesn't call skipBytes which unnecessarily
  copies the entire slice and throws it away
* add .zig-cache to .gitignore for zig 0.13.0