### PR TITLE
add zware-run to run wasm binaries from the command-line

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,6 +57,24 @@ pub fn build(b: *Build) !void {
     const test_step = b.step("test", "Run all the tests");
     test_step.dependOn(unittest_step);
     test_step.dependOn(testsuite_step);
+
+    {
+        const exe = b.addExecutable(.{
+            .name = "zware-run",
+            .root_source_file = b.path("tools/zware-run/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        exe.root_module.addImport("zware", zware_module);
+        const install = b.addInstallArtifact(exe, .{});
+        b.getInstallStep().dependOn(&install.step);
+        const run = b.addRunArtifact(exe);
+        run.step.dependOn(&install.step);
+        if (b.args) |args| {
+            run.addArgs(args);
+        }
+        b.step("run", "Run the cmdline runner zware-run").dependOn(&run.step);
+    }
 }
 
 fn addWast2Json(b: *Build) *Build.Step.Compile {

--- a/src/error.zig
+++ b/src/error.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+const module = @import("module.zig");
+
+/// A function can take a reference to this to pass extra error information to the caller.
+/// A function that does this guarantees the reference will be populated if it returns error.SeeContext.
+/// Error implements a format function.
+/// The same error instance can be re-used for multiple calls.
+///
+/// Example usage:
+/// ----
+/// var zware_error: Error = undefined;
+/// foo(&zware_error) catch |err| switch (err) {
+///     error.SeeContext => std.log.err("foo failed: {}", .{zware_error}),
+///     else => |err| return err,
+/// };
+/// ---
+pub const Error = union(enum) {
+    missing_import: module.Import,
+    any: anyerror,
+
+    /// Called by a function that wants to both populate this error instance and let the caller
+    /// know it's been populated by returning error.SeeContext.
+    pub fn set(self: *Error, e: Error) error{SeeContext} {
+        self.* = e;
+        return error.SeeContext;
+    }
+    pub fn format(
+        self: Error,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+        switch (self) {
+            .missing_import => |import| try writer.print(
+                "missing {s} import '{s}' from module '{s}'",
+                .{ @tagName(import.desc_tag), import.name, import.module },
+            ),
+            .any => |e| try writer.print("{s}", .{@errorName(e)}),
+        }
+    }
+};

--- a/src/instance/vm.zig
+++ b/src/instance/vm.zig
@@ -295,7 +295,7 @@ pub const VirtualMachine = struct {
                 next_ip = f.start;
             },
             .host_function => |hf| {
-                try hf.func(self);
+                try hf.func(self, hf.context);
                 next_ip = ip + 1;
             },
         }
@@ -350,7 +350,7 @@ pub const VirtualMachine = struct {
                 next_ip = func.start;
             },
             .host_function => |host_func| {
-                try host_func.func(self);
+                try host_func.func(self, host_func.context);
 
                 next_ip = ip + 1;
             },

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,6 @@
+pub const Error = @import("error.zig").Error;
 pub const Module = @import("module.zig").Module;
+pub const FuncType = @import("module.zig").FuncType;
 pub const Instance = @import("instance.zig").Instance;
 pub const VirtualMachine = @import("instance/vm.zig").VirtualMachine;
 pub const WasmError = @import("instance/vm.zig").WasmError;

--- a/src/module.zig
+++ b/src/module.zig
@@ -138,7 +138,7 @@ pub const Module = struct {
         return count;
     }
 
-    pub fn getExport(self: *Module, tag: Tag, name: []const u8) !usize {
+    pub fn getExport(self: *const Module, tag: Tag, name: []const u8) !usize {
         for (self.exports.list.items) |exported| {
             if (tag == exported.tag and mem.eql(u8, name, exported.name)) return exported.index;
         }
@@ -841,7 +841,7 @@ fn Section(comptime T: type) type {
             return self.list.items;
         }
 
-        pub fn lookup(self: *Self, idx: anytype) !T {
+        pub fn lookup(self: *const Self, idx: anytype) !T {
             const index = switch (@TypeOf(idx)) {
                 u32 => idx,
                 usize => math.cast(u32, idx) orelse return error.IndexTooLarge,

--- a/src/store/function.zig
+++ b/src/store/function.zig
@@ -16,7 +16,8 @@ pub const Function = struct {
             instance: *Instance,
         },
         host_function: struct {
-            func: *const fn (*VirtualMachine) WasmError!void,
+            func: *const fn (*VirtualMachine, usize) WasmError!void,
+            context: usize,
         },
     },
 

--- a/test/testrunner/src/testrunner.zig
+++ b/test/testrunner/src/testrunner.zig
@@ -34,37 +34,37 @@ const WasmError = zware.WasmError;
 
 var gpa = GeneralPurposeAllocator(.{}){};
 
-fn print(_: *VirtualMachine) WasmError!void {
+fn print(_: *VirtualMachine, _: usize) WasmError!void {
     std.debug.print("print\n", .{});
 }
 
-fn print_i32(vm: *VirtualMachine) WasmError!void {
+fn print_i32(vm: *VirtualMachine, _: usize) WasmError!void {
     const value = vm.popOperand(i32);
     std.debug.print("print_i32: {}\n", .{value});
 }
 
-fn print_i64(vm: *VirtualMachine) WasmError!void {
+fn print_i64(vm: *VirtualMachine, _: usize) WasmError!void {
     const value = vm.popOperand(i64);
     std.debug.print("print_i64: {}\n", .{value});
 }
 
-fn print_f32(vm: *VirtualMachine) WasmError!void {
+fn print_f32(vm: *VirtualMachine, _: usize) WasmError!void {
     const value = vm.popOperand(f32);
     std.debug.print("print_f32: {}\n", .{value});
 }
 
-fn print_f64(vm: *VirtualMachine) WasmError!void {
+fn print_f64(vm: *VirtualMachine, _: usize) WasmError!void {
     const value = vm.popOperand(f64);
     std.debug.print("print_f64: {}\n", .{value});
 }
 
-fn print_i32_f32(vm: *VirtualMachine) WasmError!void {
+fn print_i32_f32(vm: *VirtualMachine, _: usize) WasmError!void {
     const value_f32 = vm.popOperand(f32);
     const value_i32 = vm.popOperand(i32);
     std.debug.print("print_i32_f32: {}, {}\n", .{ value_i32, value_f32 });
 }
 
-fn print_f64_f64(vm: *VirtualMachine) WasmError!void {
+fn print_f64_f64(vm: *VirtualMachine, _: usize) WasmError!void {
     const value_f64_2 = vm.popOperand(f64);
     const value_f64_1 = vm.popOperand(f64);
     std.debug.print("print_f64_f64: {}, {}\n", .{ value_f64_1, value_f64_2 });
@@ -113,13 +113,13 @@ pub fn main() anyerror!void {
     try store.exposeGlobal(spectest, "global_f64", 666, .F64, .Immutable);
 
     // Expose host functions
-    try store.exposeHostFunction(spectest, "print", print, &[_]ValType{}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_i32", print_i32, &[_]ValType{.I32}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_i64", print_i64, &[_]ValType{.I64}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_f32", print_f32, &[_]ValType{.F32}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_f64", print_f64, &[_]ValType{.F64}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_i32_f32", print_i32_f32, &[_]ValType{.I32, .F32}, &[_]ValType{});
-    try store.exposeHostFunction(spectest, "print_f64_f64", print_f64_f64, &[_]ValType{.F64, .F64}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print", print, 0, &[_]ValType{}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_i32", print_i32, 0, &[_]ValType{.I32}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_i64", print_i64, 0, &[_]ValType{.I64}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_f32", print_f32, 0, &[_]ValType{.F32}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_f64", print_f64, 0, &[_]ValType{.F64}, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_i32_f32", print_i32_f32, 0, &[_]ValType{ .I32, .F32 }, &[_]ValType{});
+    try store.exposeHostFunction(spectest, "print_f64_f64", print_f64_f64, 0, &[_]ValType{ .F64, .F64 }, &[_]ValType{});
 
     var current_instance: *Instance = undefined;
     var registered_names = StringHashMap(*Instance).init(alloc);
@@ -893,7 +893,6 @@ const CommandRegister = struct {
     as: []const u8,
 };
 
-
 const Action = union(enum) {
     invoke: ActionInvoke,
     get: ActionGet,
@@ -928,7 +927,6 @@ const ActionGet = struct {
     field: []const u8,
     module: ?[]const u8 = null,
 };
-
 
 const Value = struct {
     type: []const u8,

--- a/tools/zware-run/main.zig
+++ b/tools/zware-run/main.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const zware = @import("zware");
+
+fn oom(e: error{OutOfMemory}) noreturn {
+    @panic(@errorName(e));
+}
+
+const ImportStub = struct {
+    module: []const u8,
+    name: []const u8,
+    type: zware.FuncType,
+};
+
+const enable_leak_detection = false;
+const global = struct {
+    var allocator_instance = if (enable_leak_detection) std.heap.GeneralPurposeAllocator(.{
+        .retain_metadata = true,
+        //.verbose_log = true,
+    }){} else std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const alloc = allocator_instance.allocator();
+    var import_stubs: std.ArrayListUnmanaged(ImportStub) = .{};
+};
+
+pub fn main() !void {
+    try main2();
+    if (enable_leak_detection) {
+        switch (global.allocator_instance.deinit()) {
+            .ok => {},
+            .leak => @panic("memory leak"),
+        }
+    }
+}
+fn main2() !void {
+    defer global.import_stubs.deinit(global.alloc);
+
+    const full_cmdline = try std.process.argsAlloc(global.alloc);
+    defer std.process.argsFree(global.alloc, full_cmdline);
+    if (full_cmdline.len <= 1) {
+        try std.io.getStdErr().writer().writeAll("Usage: zware-run FILE.wasm FUNCTION\n");
+        std.process.exit(0xff);
+    }
+
+    const pos_args = full_cmdline[1..];
+    if (pos_args.len != 2) {
+        std.log.err("expected {} positional cmdline arguments but got {}", .{ 2, pos_args.len });
+        std.process.exit(0xff);
+    }
+    const wasm_path = pos_args[0];
+    const wasm_func_name = pos_args[1];
+
+    var store = zware.Store.init(global.alloc);
+    defer store.deinit();
+
+    const wasm_content = content_blk: {
+        var file = std.fs.cwd().openFile(wasm_path, .{}) catch |e| {
+            std.log.err("failed to open '{s}': {s}", .{ wasm_path, @errorName(e) });
+            std.process.exit(0xff);
+        };
+        defer file.close();
+        break :content_blk try file.readToEndAlloc(global.alloc, std.math.maxInt(usize));
+    };
+    defer global.alloc.free(wasm_content);
+
+    var module = zware.Module.init(global.alloc, wasm_content);
+    defer module.deinit();
+    try module.decode();
+
+    const export_funcidx = try getExportFunction(&module, wasm_func_name);
+    const export_funcdef = module.functions.list.items[export_funcidx];
+    const export_functype = try module.types.lookup(export_funcdef.typeidx);
+    if (export_functype.params.len != 0) {
+        std.log.err("calling a function with parameters is not implemented", .{});
+        std.process.exit(0xff);
+    }
+
+    var instance = zware.Instance.init(global.alloc, &store, module);
+    defer if (enable_leak_detection) instance.deinit();
+
+    try populateMissingImports(&store, &module);
+
+    var zware_error: zware.Error = undefined;
+    instance.instantiateWithError(&zware_error) catch |err| switch (err) {
+        error.SeeContext => {
+            std.log.err("failed to instantiate the module: {}", .{zware_error});
+            std.process.exit(0xff);
+        },
+        else => |e| return e,
+    };
+    defer instance.deinit();
+
+    var in = [_]u64{};
+    const out_args = try global.alloc.alloc(u64, export_functype.results.len);
+    defer global.alloc.free(out_args);
+    try instance.invoke(wasm_func_name, &in, out_args, .{});
+    std.log.info("{} output(s)", .{out_args.len});
+    for (out_args, 0..) |out_arg, out_index| {
+        std.log.info("output {} {}", .{ out_index, fmtValue(export_functype.results[out_index], out_arg) });
+    }
+}
+
+fn getExportFunction(module: *const zware.Module, func_name: []const u8) !usize {
+    return module.getExport(.Func, func_name) catch |err| switch (err) {
+        error.ExportNotFound => {
+            const stderr = std.io.getStdErr().writer();
+            var export_func_count: usize = 0;
+            for (module.exports.list.items) |exp| {
+                if (exp.tag == .Func) {
+                    export_func_count += 1;
+                }
+            }
+            if (export_func_count == 0) {
+                try stderr.print("error: this wasm binary has no function exports\n", .{});
+            } else {
+                try stderr.print(
+                    "error: no export function named '{s}', pick from one of the following {} export(s):\n",
+                    .{ func_name, export_func_count },
+                );
+                for (module.exports.list.items) |exp| {
+                    if (exp.tag == .Func) {
+                        try stderr.print("     {s}\n", .{exp.name});
+                    }
+                }
+            }
+            std.process.exit(0xff);
+        },
+    };
+}
+
+fn populateMissingImports(store: *zware.Store, module: *const zware.Module) !void {
+    var import_funcidx: u32 = 0;
+    var import_memidx: u32 = 0;
+    for (module.imports.list.items, 0..) |import, import_index| {
+        defer switch (import.desc_tag) {
+            .Func => import_funcidx += 1,
+            .Mem => import_memidx += 1,
+            else => @panic("todo"),
+        };
+
+        if (store.import(import.module, import.name, import.desc_tag)) |_| {
+            continue;
+        } else |err| switch (err) {
+            error.ImportNotFound => {},
+        }
+
+        switch (import.desc_tag) {
+            .Func => {
+                const funcdef = module.functions.list.items[import_funcidx];
+                std.debug.assert(funcdef.import.? == import_index);
+                const functype = try module.types.lookup(funcdef.typeidx);
+                global.import_stubs.append(global.alloc, .{
+                    .module = import.module,
+                    .name = import.name,
+                    .type = functype,
+                }) catch |e| oom(e);
+                store.exposeHostFunction(
+                    import.module,
+                    import.name,
+                    onMissingImport,
+                    global.import_stubs.items.len - 1,
+                    functype.params,
+                    functype.results,
+                ) catch |e2| oom(e2);
+            },
+            .Mem => {
+                const memdef = module.memories.list.items[import_memidx];
+                std.debug.assert(memdef.import.? == import_index);
+                try store.exposeMemory(import.module, import.name, memdef.limits.min, memdef.limits.max);
+            },
+            else => |tag| std.debug.panic("todo: handle import {s}", .{@tagName(tag)}),
+        }
+    }
+}
+
+fn onMissingImport(vm: *zware.VirtualMachine, context: usize) zware.WasmError!void {
+    const stub = global.import_stubs.items[context];
+    std.log.info("import function '{s}.{s}' called", .{ stub.module, stub.name });
+    for (stub.type.params, 0..) |param_type, i| {
+        const value = vm.popAnyOperand();
+        std.log.info("    param {} {}", .{ i, fmtValue(param_type, value) });
+    }
+    for (stub.type.results, 0..) |result_type, i| {
+        std.log.info("    result {} {}", .{ i, fmtValue(result_type, 0) });
+        try vm.pushOperand(u64, 0);
+    }
+}
+
+pub fn Native(comptime self: zware.ValType) type {
+    return switch (self) {
+        .I32 => i32,
+        .I64 => i64,
+        .F32 => f32,
+        .F64 => f64,
+        .V128 => u64,
+        .FuncRef => u64,
+        .ExternRef => u64,
+    };
+}
+
+fn cast(comptime val_type: zware.ValType, value: u64) Native(val_type) {
+    return switch (val_type) {
+        .I32 => @bitCast(@as(u32, @intCast(value))),
+        .I64 => @bitCast(value),
+        .F32 => @bitCast(@as(u32, @intCast(value))),
+        .F64 => @bitCast(value),
+        .V128 => value,
+        .FuncRef => value,
+        .ExternRef => value,
+    };
+}
+
+fn fmtValue(val_type: zware.ValType, value: u64) FmtValue {
+    return .{ .type = val_type, .value = value };
+}
+const FmtValue = struct {
+    type: zware.ValType,
+    value: u64,
+    pub fn format(
+        self: FmtValue,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+        switch (self.type) {
+            inline else => |t2| try writer.print("({s}) {}", .{ @tagName(t2), cast(t2, self.value) }),
+        }
+    }
+};


### PR DESCRIPTION
An initial version of a command-line program that can take a WASM binary on the command line and a function name and execute it.

It will find missing imports and populate them with "stubs". The stub will log the call and then populate the results with "zeroed" values. An enhancement could be to take multiple files on the command line and link them together before execution.

A few examples of binaries I could use with this was:

   - binaries from the test suite
   - WASM4 binaries
   - the Zig wasm executable

Of the ones I tested this seems like a viable strategy to quickly run the binaries from the test suite.  The WASM4/Zig binaries would usually just call a function or two and then hit an assert because of the "zeroed" results that are produced by the stubs.