### PR TITLE
Reverse the Order of Deinitialization for Allocated Struct Members 

### DIFF
--- a/src/instance.zig
+++ b/src/instance.zig
@@ -77,16 +77,16 @@ pub const Instance = struct {
     }
 
     pub fn deinit(self: *Instance) void {
-        self.funcaddrs.deinit();
-        self.memaddrs.deinit();
-        self.tableaddrs.deinit();
-        self.globaladdrs.deinit();
-        self.elemaddrs.deinit();
-        self.dataaddrs.deinit();
+        defer self.funcaddrs.deinit();
+        defer self.memaddrs.deinit();
+        defer self.tableaddrs.deinit();
+        defer self.globaladdrs.deinit();
+        defer self.elemaddrs.deinit();
+        defer self.dataaddrs.deinit();
 
-        self.wasi_preopens.deinit();
-        self.wasi_args.deinit();
-        self.wasi_env.deinit();
+        defer self.wasi_preopens.deinit();
+        defer self.wasi_args.deinit();
+        defer self.wasi_env.deinit();
     }
 
     pub fn getFunc(self: *Instance, funcidx: usize) !Function {

--- a/src/module.zig
+++ b/src/module.zig
@@ -61,23 +61,23 @@ pub const Module = struct {
     }
 
     pub fn deinit(self: *Module) void {
-        self.customs.deinit();
-        self.types.deinit();
-        self.imports.deinit();
-        self.functions.deinit();
-        self.tables.deinit();
-        self.memories.deinit();
-        self.globals.deinit();
-        self.exports.deinit();
-        self.elements.deinit();
-        self.codes.deinit();
-        self.datas.deinit();
+        defer self.customs.deinit();
+        defer self.types.deinit();
+        defer self.imports.deinit();
+        defer self.functions.deinit();
+        defer self.tables.deinit();
+        defer self.memories.deinit();
+        defer self.globals.deinit();
+        defer self.exports.deinit();
+        defer self.elements.deinit();
+        defer self.codes.deinit();
+        defer self.datas.deinit();
 
-        self.element_init_offsets.deinit();
-        self.parsed_code.deinit();
-        self.local_types.deinit();
-        self.br_table_indices.deinit();
-        self.references.deinit();
+        defer self.element_init_offsets.deinit();
+        defer self.parsed_code.deinit();
+        defer self.local_types.deinit();
+        defer self.br_table_indices.deinit();
+        defer self.references.deinit();
     }
 
     pub fn decode(self: *Module) !void {

--- a/src/store.zig
+++ b/src/store.zig
@@ -57,6 +57,14 @@ pub const ArrayListStore = struct {
     }
 
     pub fn deinit(self: *ArrayListStore) void {
+        defer self.functions.deinit();
+        defer self.memories.deinit();
+        defer self.tables.deinit();
+        defer self.globals.deinit();
+        defer self.elems.deinit();
+        defer self.datas.deinit();
+        defer self.imports.deinit();
+
         for (self.memories.items) |*m| {
             m.deinit();
         }
@@ -69,14 +77,6 @@ pub const ArrayListStore = struct {
         for (self.datas.items) |*d| {
             d.deinit();
         }
-
-        self.functions.deinit();
-        self.memories.deinit();
-        self.tables.deinit();
-        self.globals.deinit();
-        self.elems.deinit();
-        self.datas.deinit();
-        self.imports.deinit();
     }
 
     // import


### PR DESCRIPTION
I want to use zware for a memory-constrained embedded project.
Unwinding objects's allocations will allow for allocated memory to be more reusable, as FixedBufferAllocators can free its last allocated memory.