### PR TITLE
update Zig version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pub fn main() !void {
 
 ### Compile-time
 
-- Zig 0.15.1 (master)
+- Zig 0.16.0
 
 ### Run-time
 


### PR DESCRIPTION
The required Zig version was not updated when the library was updated to Zig 0.16.0